### PR TITLE
feat: replace snyk with snyk-protect and fix some vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@hapi/boom": "^10.0.0",
+        "@snyk/protect": "^1.1044.0",
         "async": "^3.2.4",
         "debug": "^4.3.4",
         "express": "^4.18.1",
@@ -19,8 +20,7 @@
         "lodash.merge": "^4.6.2",
         "lodash.once": "^4.1.1",
         "parse-duration": "^1.0.2",
-        "server-destroy": "^1.0.1",
-        "snyk": "^1.986.0"
+        "server-destroy": "^1.0.1"
       },
       "devDependencies": {
         "eslint": "7.32.0",
@@ -182,6 +182,17 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
+    },
+    "node_modules/@snyk/protect": {
+      "version": "1.1044.0",
+      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.1044.0.tgz",
+      "integrity": "sha512-Wi6zmOMsyM2FRlxvqLo3opf7SDvcpWWR3RGJVHPVg6uh7VByAYrKome1zl8WRUaBr4qfEpL0jJLFKaBkHYUlAg==",
+      "bin": {
+        "snyk-protect": "bin/snyk-protect"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -1274,9 +1285,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1670,17 +1681,6 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/snyk": {
-      "version": "1.986.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.986.0.tgz",
-      "integrity": "sha512-u61QevBUVWBUEaZhq+zElxLrLEuQ4tgWenzagTkmTgXqRAe/S5M4y7WJwQSHfie+qt6xn37BDl9/ACyH3XAFEg==",
-      "bin": {
-        "snyk": "bin/snyk"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -2062,6 +2062,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
+    },
+    "@snyk/protect": {
+      "version": "1.1044.0",
+      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.1044.0.tgz",
+      "integrity": "sha512-Wi6zmOMsyM2FRlxvqLo3opf7SDvcpWWR3RGJVHPVg6uh7VByAYrKome1zl8WRUaBr4qfEpL0jJLFKaBkHYUlAg=="
     },
     "accepts": {
       "version": "1.3.8",
@@ -2923,9 +2928,9 @@
       }
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -3215,11 +3220,6 @@
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
       }
-    },
-    "snyk": {
-      "version": "1.986.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.986.0.tgz",
-      "integrity": "sha512-u61QevBUVWBUEaZhq+zElxLrLEuQ4tgWenzagTkmTgXqRAe/S5M4y7WJwQSHfie+qt6xn37BDl9/ACyH3XAFEg=="
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "snyk-protect": "snyk protect",
+    "snyk-protect": "snyk-protect",
     "prepublish": "npm run snyk-protect",
     "eslint": "eslint . --ext .js --config .eslintrc.json --ignore-path .eslintignore --cache",
     "eslint:fix": "eslint . --ext .js --fix",
@@ -15,6 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "@hapi/boom": "^10.0.0",
+    "@snyk/protect": "^1.1044.0",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "express": "^4.18.1",
@@ -24,8 +25,7 @@
     "lodash.merge": "^4.6.2",
     "lodash.once": "^4.1.1",
     "parse-duration": "^1.0.2",
-    "server-destroy": "^1.0.1",
-    "snyk": "^1.986.0"
+    "server-destroy": "^1.0.1"
   },
   "keywords": [
     "Systemic",


### PR DESCRIPTION
### Main changes

- :cloud: (ci)

### Additional notes

Snyk protect is [no longer supported](https://updates.snyk.io/snyk-wizard-and-snyk-protect-removal-224137). This PR replaces it and also fixes a couple of vulnerabilities that snyk detected.
